### PR TITLE
fix: set mihomo User-Agent for subscription downloads

### DIFF
--- a/ClashX/General/Managers/RemoteConfigManager.swift
+++ b/ClashX/General/Managers/RemoteConfigManager.swift
@@ -137,6 +137,19 @@ class RemoteConfigManager {
         }
     }
 
+    /// User-Agent sent when downloading remote subscription configs.
+    ///
+    /// Many subscription providers gate their Clash/mihomo-format response on the
+    /// request User-Agent. The historical ClashX UA (`ClashX/x.y.z ... Alamofire/x`)
+    /// is frequently treated as a legacy Dreamacro/clash client and is either
+    /// blocked or served a dummy config, because it does not support SS-2022 and
+    /// other modern protocols.
+    ///
+    /// This fork actually ships the mihomo (Clash.Meta) core, so declaring
+    /// `mihomo/<version>` is both accurate and recognised by provider whitelists.
+    /// See https://github.com/ClashX-Pro/ClashX/issues/16.
+    private static let subscriptionUserAgent = "mihomo/1.19.11"
+
     static func getRemoteConfigData(config: RemoteConfigModel, complete: @escaping ((String?, String?) -> Void)) {
         guard var urlRequest = try? URLRequest(url: config.url, method: .get) else {
             assertionFailure()
@@ -144,6 +157,7 @@ class RemoteConfigManager {
             return
         }
         urlRequest.cachePolicy = .reloadIgnoringCacheData
+        urlRequest.setValue(subscriptionUserAgent, forHTTPHeaderField: "User-Agent")
 
         AF.request(urlRequest)
             .validate()


### PR DESCRIPTION
## Summary

- Set `User-Agent: mihomo/1.19.11` on subscription download requests in `RemoteConfigManager.getRemoteConfigData`
- Fixes providers that return dummy / empty configs to ClashX because they detect the default Alamofire UA containing "ClashX" as a legacy Dreamacro/clash client

## Problem

Many Chinese subscription providers gate their Clash/mihomo YAML response on the request `User-Agent`. Our subscription downloader was using Alamofire's default UA, which looks like:

```
ClashX/1.125.0 (com.west2online.ClashX; build:1.125.0; macOS 10.15.7) Alamofire/5.x
```

Because legacy Dreamacro/clash (which ClashX historically embedded) does not support SS-2022 and other modern protocols, providers often treat any UA containing `ClashX` as a legacy client and:

- block the request entirely, or
- serve a "sentinel" config that tells the user to upgrade, e.g.:

  ```yaml
  proxies:
    - { name: 如果没有显示节点, type: ss, server: 8.8.8.8, port: 30000, ... }
    - { name: 请仔细看官网公告, type: ss, server: 1.1.1.1, port: 30001, ... }
  ```

Users then see "zero nodes" or only these two dummy entries, exactly as reported in #16.

## Why this fork is not actually legacy

This fork already ships the mihomo (Clash.Meta) core (verified via `strings goClash.a` — contains `github.com/metacubex/mihomo/...` packages and full `sing-shadowsocks/shadowaead_2022` cipher set). SS-2022 and other modern protocols work fine once the real config is downloaded — the only thing that was wrong was the UA advertising us as "ClashX".

## Fix

Add one header to the existing `URLRequest` inside `getRemoteConfigData`:

```swift
urlRequest.setValue("mihomo/1.19.11", forHTTPHeaderField: "User-Agent")
```

The value is a truthful statement (our core _is_ mihomo) and matches the UA whitelist convention followed by Clash Verge, Mihomo Party and the official mihomo project itself.

A doc comment on the new private constant explains the rationale so a future maintainer doesn't "clean it up" and reintroduce the bug.

## Scope

- Only touches subscription downloads (`RemoteConfigManager`)
- Does **not** change the GeoIP MMDB downloader in `ClashResourceManager` — that talks to GitHub, not provider APIs
- Does **not** touch the local mihomo REST API client (`ApiRequest` → `127.0.0.1`)

## Verification

- `xcodebuild -workspace ClashX.xcworkspace -scheme ClashX -configuration Debug build` → **BUILD SUCCEEDED**
- No new SwiftLint warnings in touched file
- Diff is +14 / -0 lines in a single file

Closes #16