### PR TITLE
fix: auto-select group, speed display, settings tab icons

### DIFF
--- a/ClashX/General/Managers/RemoteConfigManager.swift
+++ b/ClashX/General/Managers/RemoteConfigManager.swift
@@ -233,6 +233,7 @@ class RemoteConfigManager {
 
         guard !proxies.isEmpty else { return nil }
 
+        let proxyList = names.joined(separator: ", ")
         return """
         mode: rule
         log-level: info
@@ -241,9 +242,14 @@ class RemoteConfigManager {
         \(proxies.joined(separator: "\n"))
 
         proxy-groups:
-          - name: \"Proxy\"
+          - name: "Auto"
+            type: url-test
+            proxies: [\(proxyList)]
+            url: "http://cp.cloudflare.com/generate_204"
+            interval: 300
+          - name: "Proxy"
             type: select
-            proxies: [\(names.joined(separator: ", "))]
+            proxies: ["Auto", \(proxyList)]
 
         rules:
           - MATCH,Proxy

--- a/ClashX/ViewControllers/Settings/SettingTabViewController.swift
+++ b/ClashX/ViewControllers/Settings/SettingTabViewController.swift
@@ -12,10 +12,12 @@ class SettingTabViewController: NSTabViewController, NibLoadable {
     override func viewDidLoad() {
         super.viewDidLoad()
         tabStyle = .toolbar
-        if #unavailable(macOS 10.11) {
-            tabStyle = .segmentedControlOnTop
-            for item in tabViewItems {
-                item.image = nil
+        // Set SF Symbol images in code — storyboard catalog images render as
+        // black squares in NSTabViewController toolbar style on macOS 15+.
+        if #available(macOS 11, *) {
+            let symbols = ["gearshape", "keyboard", "hammer"]
+            for (idx, item) in tabViewItems.enumerated() where idx < symbols.count {
+                item.image = NSImage(systemSymbolName: symbols[idx], accessibilityDescription: nil)
             }
         }
         NSApp.activate(ignoringOtherApps: true)

--- a/ClashX/Views/StatusItem/StatusItemView.swift
+++ b/ClashX/Views/StatusItem/StatusItemView.swift
@@ -17,8 +17,9 @@ class StatusItemView: NSView, StatusItemViewProtocol {
 
     private var speedTextView: SpeedTextView!
 
-    var up: Int = 0
-    var down: Int = 0
+    // Use -1 so the first updateSpeedLabel(0, 0) call always triggers a redraw.
+    var up: Int = -1
+    var down: Int = -1
 
     weak var statusItem: NSStatusItem?
 


### PR DESCRIPTION
## 修复内容

### 1. 自动节点功能恢复
`buildConfigFromShareLinks` 生成的 YAML 只有 `select` 组，缺少自动测速组。现在新增 `url-test` 类型的 `Auto` 组，并放在 `Proxy` 选择组的首位。

### 2. 菜单栏网速显示空白
`StatusItemView.up/down` 初始值为 `0`，导致第一次收到 `(0, 0)` 流量回调时被跳过，`SpeedTextView` 的 `needsDisplay` 从未触发。将初始值改为 `-1`，确保第一次回调必然触发重绘。

### 3. 设置界面 Tab 图标黑块（macOS 15）
`NSTabViewController` 在 `.toolbar` 样式下，从 Storyboard catalog 加载的 SF Symbol 在 macOS 15+ 渲染为黑色方块。改为在 `viewDidLoad` 中用 `NSImage(systemSymbolName:)` 代码方式加载（macOS 11+），绕过 Storyboard 渲染路径。

## 根因
| # | 回归来源 | 引入 commit |
|---|---|---|
| 1 | 本次新增 SS 订阅解析时漏写 url-test 组 | `e6020d93` |
| 2 | #15 高 CPU 修复时引入的回归 | `615ea2ee` |
| 3 | 原始代码历史遗留，macOS 15 下一直存在 | `d675b0a6` |

Made with [Cursor](https://cursor.com)