### PR TITLE
fix: align share-link Go DNS defaults with DoH/DoT (parity with Swift template)

### DIFF
--- a/ClashX/goClash/main.go
+++ b/ClashX/goClash/main.go
@@ -227,13 +227,24 @@ func clashConvertShareLinks(content *C.char) *C.char {
 			"enable":        true,
 			"ipv6":          false,
 			"enhanced-mode": "redir-host",
-			"nameserver": []string{
+			"default-nameserver": []string{
+				"114.114.114.114",
 				"223.5.5.5",
 				"119.29.29.29",
 			},
+			"nameserver": []string{
+				"https://223.5.5.5/dns-query",
+				"https://doh.pub/dns-query",
+				"119.29.29.29",
+				"223.5.5.5",
+				"tls://223.5.5.5:853",
+				"tls://223.6.6.6:853",
+			},
 			"fallback": []string{
-				"1.1.1.1",
-				"8.8.8.8",
+				"https://223.5.5.5/dns-query",
+				"https://doh.pub/dns-query",
+				"tls://1.1.1.1:853",
+				"tls://8.8.8.8:853",
 			},
 			"fallback-filter": map[string]interface{}{
 				"geoip":      true,


### PR DESCRIPTION
## Summary

Fixes a missed leg of the v1.138.0 DNS-over-UDP/53 fix. The Swift `RemoteConfigManager` template was upgraded to DoH/DoT in commit [2ab6fda8](https://github.com/ClashX-Pro/ClashX/commit/2ab6fda8), but the **Go-side share-link conversion** (`clashConvertShareLinks` in [`goClash/main.go`](https://github.com/ClashX-Pro/ClashX/blob/master/ClashX/goClash/main.go)) still emitted plain UDP/53 DNS. Users on this code path continued to hit `dns resolve failed: i/o timeout` against `1.1.1.1:53` / `8.8.8.8:53` — exactly the symptom v1.138.0 was supposed to eliminate.

## Why It Matters

Two scenarios bite users on the Go path:

1. **Enterprise SSL VPN coexistence** — clients like SangFor Easy Connect install a PF DNAT rule that redirects all `dport 53` UDP traffic to an internal DNS proxy that can't resolve public Chinese domains. With plain UDP/53 fallback, every GeoSite/cn DIRECT route fails. (User report: [#16](https://github.com/ClashX-Pro/ClashX/issues/16) — log shows ` dial udp 1.1.1.1:53: i/o timeout` against `www.doubao.com`, `qq.com`.)
2. **Polluted ISP DNS / UDP throttling** — same class of failure documented in [#2ab6fda8](https://github.com/ClashX-Pro/ClashX/commit/2ab6fda8) commit message.

After upgrading to 1.138.0, users still saw failures because their share-link conversion flow went through the Go function, not the Swift template.

## Change

One block of `clashConvertShareLinks` in `goClash/main.go`:

\`\`\`diff
 \"dns\": map[string]interface{}{
   \"enable\":        true,
   \"ipv6\":          false,
   \"enhanced-mode\": \"redir-host\",
-  \"nameserver\": []string{
+  \"default-nameserver\": []string{
+    \"114.114.114.114\",
     \"223.5.5.5\",
     \"119.29.29.29\",
   },
+  \"nameserver\": []string{
+    \"https://223.5.5.5/dns-query\",
+    \"https://doh.pub/dns-query\",
+    \"119.29.29.29\",
+    \"223.5.5.5\",
+    \"tls://223.5.5.5:853\",
+    \"tls://223.6.6.6:853\",
+  },
   \"fallback\": []string{
-    \"1.1.1.1\",
-    \"8.8.8.8\",
+    \"https://223.5.5.5/dns-query\",
+    \"https://doh.pub/dns-query\",
+    \"tls://1.1.1.1:853\",
+    \"tls://8.8.8.8:853\",
   },
\`\`\`

Field-for-field parity with [the v1.138.0 Swift template](https://github.com/ClashX-Pro/ClashX/blob/master/ClashX/General/Managers/RemoteConfigManager.swift#L270-L291) and with [ClashFX's `nameserverPolicyForConvertedProxies`](https://github.com/Clash-FX/ClashFX/blob/main/ClashFX/goClash/main.go#L491-L509).

## Local Verification

Rebuilt `goClash.a` after the patch:

| Metric | Before | After |
|---|---|---|
| `goClash.a` size | 173,193,192 B | 173,193,928 B (+736 B, string-only) |
| `https://doh.pub/dns-query` in archive | absent | present |
| `tls://223.5.5.5:853` in archive | absent | present |
| `tls://223.6.6.6:853` in archive | absent | present |
| `tls://1.1.1.1:853` in archive | absent | present |
| `tls://8.8.8.8:853` in archive | absent | present |

Build clean through `arm64` + `amd64` + universal `lipo` merge.

## Impact

- **Easy Connect / corporate SSL VPN users** can finally use DIRECT-routed CN domains.
- **Throttled / polluted UDP/53 networks** no longer time out on initial DIRECT DNS.
- **No new dependencies, no API changes** — runtime behavior identical for users on healthy plaintext UDP/53 networks (DoH/DoT is added before plaintext, mihomo races them).
- **No template-version migration needed** — Swift path migration in v1.138.0 already covers existing user configs; this PR ensures *new* share-link imports go through the same DNS template.