### PR TITLE
fix: keep proxy selector at top of status menu

### DIFF
--- a/ClashX/AppDelegate.swift
+++ b/ClashX/AppDelegate.swift
@@ -403,8 +403,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         for _ in 0 ..< endIndex - startIndex {
             statusMenu.removeItem(at: startIndex)
         }
-        for each in menus {
-            statusMenu.insertItem(each, at: startIndex)
+        for (offset, each) in menus.enumerated() {
+            statusMenu.insertItem(each, at: startIndex + offset)
         }
     }
 

--- a/ClashX/General/Managers/MenuItemFactory.swift
+++ b/ClashX/General/Managers/MenuItemFactory.swift
@@ -123,8 +123,8 @@ class MenuItemFactory {
         for _ in 0 ..< endIndex - startIndex {
             app.statusMenu.removeItem(at: startIndex)
         }
-        for each in menus {
-            app.statusMenu.insertItem(each, at: startIndex)
+        for (offset, each) in menus.enumerated() {
+            app.statusMenu.insertItem(each, at: startIndex + offset)
         }
     }
 


### PR DESCRIPTION
## What changed

- Preserve the prioritized proxy-group order when inserting status-menu items.
- Apply the same order-preserving insertion logic to both menu update paths.

## Root cause

Proxy groups were sorted with `select` first, but every item was then inserted at the same menu index. AppKit consequently reversed the sorted array, leaving the proxy selector below automatic and fallback groups.

## User impact

The selectable proxy group now appears at the top of the proxy section as expected.

## Validation

- `bundle exec fastlane check`
- SwiftFormat lint on both changed Swift files
- Deterministic insertion-order assertion

Refs #23