### PR TITLE
ci: normalize escaped newlines in release notes

### DIFF
--- a/scripts/generate_release_notes.py
+++ b/scripts/generate_release_notes.py
@@ -334,6 +334,7 @@ def clean_title(text):
 
 def first_paragraph(body):
     """Extract first meaningful paragraph from commit body."""
+    body = body.replace("\\n", "\n")
     lines = []
     for line in body.split("\n"):
         stripped = line.strip()


### PR DESCRIPTION
## What changed

Normalize literal newline escape sequences before extracting the first commit-body paragraph for generated release notes.

## Why

A CLI-created commit body can contain literal `\\n` sequences. Without normalization, those escapes appear verbatim in both the GitHub Release body and the Sparkle appcast summary.

## Validation

- `python3 -m py_compile scripts/generate_release_notes.py`
- Assertions for escaped and real newline input
- Full `1.140.0` release-note preview